### PR TITLE
Add Akephalos to Self-Hosted Personal Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Your Context (what makes AI understand YOU)
 - [Memspan](https://memspan.ai/) - File-first personal memory, portable
 
 ### Self-Hosted Personal Memory
+- [Akephalos](https://github.com/sunnja69/akephalos) - Local-first, markdown-first `.akephalos` passport and MCP stdio server for portable preferences, tool notes, rules, project context, and durable memories across agents/tools via plain files and Git.
 - [Jean Memory](https://www.reddit.com/r/ClaudeAI/comments/1l17qf6) - Remote personal memory for Claude
 - [Sem-Mem](https://www.reddit.com/r/AIMemory/comments/1pg5fro) - Local semantic memory system
 - [MemLayer](https://www.reddit.com/r/LocalLLaMA/comments/1ozbzpx) - Persistent memory for local LLMs


### PR DESCRIPTION
## Summary

Adds Akephalos to the Self-Hosted Personal Memory section.

Akephalos is a local-first, markdown-first `.akephalos` passport and MCP stdio server for portable preferences, tool notes, rules, project context, and durable memories across agents/tools and machines via plain files/Git.

## Fit

- Relevant to context engineering and personal context management.
- Fits the list's requested categories: personal memory projects/services, MCP servers/integrations, and memory/persistence.
- Core content is public/open-source and not paywalled.

## Notes

Akephalos is early v0.1/MVP-stage; this entry intentionally avoids claiming hosted sync, automatic real-time sync, dashboards, npm availability, vector DB, or production maturity.
