### PR TITLE
Add tracecraft to watchlist (server-less multi-agent coordination substrate)

### DIFF
--- a/watchlist.md
+++ b/watchlist.md
@@ -13,7 +13,7 @@ These projects are relevant to AI second-brain architecture but are not yet full
 | Dory | Local-first shared memory daemon for MCP-aware agents. | Emerging local-first second-brain candidate. |
 | Open Second Brain | Obsidian-native memory layer for agents. | Emerging Obsidian/MCP candidate; separate from OpenHuman. |
 | MAGI | Persistent memory for AI agents. | Emerging AI-memory candidate. |
-| [tracecraft](https://github.com/Arrmlet/tracecraft) | Server-less, vendor-neutral substrate where multiple agents share state (memory, atomic task claims, handoffs) and each agent's full session trace lands as plain JSON in any S3-compatible or HuggingFace bucket you own. | Emerging coordination-substrate candidate; sits below a memory layer, not a memory layer itself. |
+| [tracecraft](https://github.com/Arrmlet/tracecraft) | Serverless multi-agent coordination substrate using S3-compatible or Hugging Face storage for shared state, task claims, handoffs, and session traces. | Emerging coordination-substrate candidate; adjacent to agent memory but not a memory layer or second-brain system itself. |
 
 ## Promotion Rule
 

--- a/watchlist.md
+++ b/watchlist.md
@@ -13,6 +13,7 @@ These projects are relevant to AI second-brain architecture but are not yet full
 | Dory | Local-first shared memory daemon for MCP-aware agents. | Emerging local-first second-brain candidate. |
 | Open Second Brain | Obsidian-native memory layer for agents. | Emerging Obsidian/MCP candidate; separate from OpenHuman. |
 | MAGI | Persistent memory for AI agents. | Emerging AI-memory candidate. |
+| [tracecraft](https://github.com/Arrmlet/tracecraft) | Server-less, vendor-neutral substrate where multiple agents share state (memory, atomic task claims, handoffs) and each agent's full session trace lands as plain JSON in any S3-compatible or HuggingFace bucket you own. | Emerging coordination-substrate candidate; sits below a memory layer, not a memory layer itself. |
 
 ## Promotion Rule
 


### PR DESCRIPTION
## What this adds

A **watchlist entry** for [tracecraft](https://github.com/Arrmlet/tracecraft) — a server-less, backend-agnostic CLI that turns any S3-compatible bucket (AWS, R2, MinIO, B2, Wasabi) or HuggingFace bucket into a durable, vendor-neutral substrate for multiple AI agents: shared key-value memory, atomic task claims, a per-agent mailbox/broadcast, and handoffs, plus each agent's full session transcript mirrored into the same bucket — all as plain JSON in a bucket you own. No server, no database, no daemon; every command is a stateless read/write against the bucket. MIT.

## Why the watchlist (and not a full profile)

I placed it under **watchlist**, not `solutions/`, on purpose. tracecraft is a *coordination* substrate, not a memory layer or a finished second brain — a memory layer or PKM app could sit on top of it. It's also early-stage. The watchlist framing ("relevant to AI second-brain architecture but not yet a full-profile entry") fits it exactly, and I'd rather under-claim than file a solution profile it can't yet back with third-party evaluation. The "Current status" cell states plainly that it sits *below* a memory layer, not that it is one.

## Sources (primary)

- Repository and docs: https://github.com/Arrmlet/tracecraft (README and project docs)
- Install: `pip install tracecraft-ai` (PyPI), MIT

## Verification notes

- **Atomic claim, benchmarked under contention.** 2 to 50 agents racing the same key simultaneously, 1,200 trials against MinIO: exactly-one-winner held on all 1,200, zero duplicate wins, verified by re-reading the durable object rather than trusting each agent's own result. A staggered control shows the latency curve is caused by simultaneity, not request count. Raw per-trial logs are committed in the repo under `benchmarks/`; the report is regenerable with `python benchmarks/build_report.py`.
- **Messaging.** The same benchmark surfaced a same-second key-collision bug (bursts from one sender collapsing onto one key); it's fixed (32/960 → 960/960 delivered under a 960-message concurrent burst) with regression tests added.

## Known limitations (stated up front)

- It is a coordination substrate, **not** a memory layer or a finished second brain.
- No claim TTL or heartbeat yet — a crashed claim-holder keeps its lock until cleared.
- The HuggingFace backend has no conditional-write primitive, so claims there are best-effort check-then-write; only S3-compatible backends get true atomicity.
- Benchmark scope is single-node MinIO over loopback, so absolute latencies are a lower bound, not cloud-S3 wall-clock; the measured contention case is a worst-case same-key stampede (agents claiming different keys are expected to stay flat but that isn't measured yet). Latency percentiles are reported on 1,176 of the 1,200 trials (24 excluded as not genuinely simultaneous; all 1,200 held the invariant).
- Early-stage: low install count, pre-launch.

## Promotion readiness

Per the watchlist promotion rule, official repo/docs, deployment model, setup burden and links, AI-tool activation surface, and known limitations all exist today; a full `solutions/tracecraft.md` profile can follow if the maintainers would like it moved up.
