### PR TITLE
docs: add screenpipe to watchlist

### DIFF
--- a/watchlist.md
+++ b/watchlist.md
@@ -14,6 +14,7 @@ These projects are relevant to AI second-brain architecture but are not yet full
 | Open Second Brain | Obsidian-native memory layer for agents. | Emerging Obsidian/MCP candidate; separate from OpenHuman. |
 | MAGI | Persistent memory for AI agents. | Emerging AI-memory candidate. |
 | [tracecraft](https://github.com/Arrmlet/tracecraft) | Serverless multi-agent coordination substrate using S3-compatible or Hugging Face storage for shared state, task claims, handoffs, and session traces. | Emerging coordination-substrate candidate; adjacent to agent memory but not a memory layer or second-brain system itself. |
+| [screenpipe](https://github.com/screenpipe/screenpipe) | Local-first 24/7 screen and microphone capture daemon that indexes OCR, accessibility, and audio transcripts into a queryable SQLite store, with MCP, REST, and SDK access for AI tools and agents. | Emerging local-first context-collection candidate; covers the Collect lifecycle stage for second-brain workflows but leaves knowledge organization and memory evolution to layers above it. |
 
 ## Promotion Rule
 


### PR DESCRIPTION
Adds [screenpipe](https://github.com/screenpipe/screenpipe) to `watchlist.md` as an emerging local-first candidate for the **Collect** lifecycle stage. Following the same pattern as the recently-added `tracecraft` entry: linked project name, one-line "why it matters", and an honest "current status" that names the lifecycle gap it covers and the gaps it does not.

Why it fits the watchlist scope (per CONTRIBUTING.md):
- Scope fit: directly addresses AI second-brain context capture and personal/team knowledge collection.
- Shipped surface: 24/7 macOS/Windows/Linux daemon recording screen and microphone, indexing OCR, accessibility tree, and Whisper transcripts into a local SQLite store.
- Activation today: MCP server, local REST API, JS/Python SDKs, CLI; works with Ollama and Claude Desktop via MCP.
- Decision value: distinct from existing entries — it is a Collect-layer substrate rather than a memory layer, end-to-end app, or platform baseline. Useful for readers whose lifecycle gap is "scattered context never enters the brain."

Not opening a core solution profile here because screenpipe is strong on Collect but does not yet meaningfully cover Organize / Evolve on its own (those are left to layers above it), which I think makes a watchlist entry the right starting point.

Disclosure: I'm the maintainer of screenpipe (louis@screenpi.pe), and this entry was prepared by screenpipe's automated contribution agent and reviewed against your CONTRIBUTING guidelines. Happy to adjust the wording, move it, or close the PR if it doesn't fit.